### PR TITLE
Improve cross compiling support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,18 @@ on: [push, pull_request]
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta, nightly]
     steps:
     - uses: actions/checkout@master
     - name: Install Rust
       run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - run: cargo test
+    - name: Integration test
+      run: cargo test --manifest-path test-crate/Cargo.toml
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,3 +40,67 @@ jobs:
           git -c user.name='ci' -c user.email='ci' commit -m init
           git push -f -q https://git:${{ secrets.github_token }}@github.com/${{ github.repository }} HEAD:gh-pages
         if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+
+  cross_compile_test:
+    name: Test Cross Compile - ${{ matrix.platform.target }}
+    needs: [ test ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          # Testable
+          - target: aarch64-unknown-linux-gnu
+            test: true
+          - target: arm-unknown-linux-gnueabihf
+            test: true
+          - target: armv7-unknown-linux-gnueabihf
+            test: true
+          - target: mips-unknown-linux-gnu
+            test: true
+          - target: mips64-unknown-linux-gnuabi64
+            test: true
+          - target: mips64el-unknown-linux-gnuabi64
+            test: true
+          - target: mipsel-unknown-linux-gnu
+            test: true
+          - target: powerpc-unknown-linux-gnu
+            test: true
+          - target: powerpc64-unknown-linux-gnu
+            test: true
+          - target: powerpc64le-unknown-linux-gnu
+            test: true
+          - target: s390x-unknown-linux-gnu
+            test: true
+          - target: x86_64-unknown-linux-musl
+            test: true
+          - target: aarch64-unknown-linux-musl
+            test: true
+          - target: x86_64-pc-windows-gnu
+            test: true
+          # Build only
+          - target: x86_64-unknown-freebsd
+            test: false
+          - target: x86_64-unknown-netbsd
+            test: false
+          - target: x86_64-sun-solaris
+            test: false
+          - target: x86_64-unknown-illumos
+            test: false
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.platform.target }}
+    - uses: taiki-e/install-action@v1
+      with:
+        tool: cross
+    - name: cross test
+      run: cross test -vv --target ${{ matrix.platform.target }}
+      working-directory: test-crate
+      if: ${{ matrix.platform.test }}
+    - name: cross build
+      run: cross build -vv --target ${{ matrix.platform.target }}
+      working-directory: test-crate
+      if: ${{ !matrix.platform.test }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,10 +448,6 @@ impl Config {
                     if !self.defined("CMAKE_SYSTEM_NAME") {
                         self.define("CMAKE_SYSTEM_NAME", "Generic");
                     }
-                } else if target.contains("solaris") {
-                    if !self.defined("CMAKE_SYSTEM_NAME") {
-                        self.define("CMAKE_SYSTEM_NAME", "SunOS");
-                    }
                 } else if target != host && !self.defined("CMAKE_SYSTEM_NAME") {
                     // Set CMAKE_SYSTEM_NAME and CMAKE_SYSTEM_PROCESSOR when cross compiling
                     let os = getenv_unwrap("CARGO_CFG_TARGET_OS");

--- a/test-crate/.gitignore
+++ b/test-crate/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/test-crate/Cargo.toml
+++ b/test-crate/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "test-crate"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libz-sys = { version = "1.1.8", default-features = false, features = ["zlib-ng"] }
+
+[patch.crates-io]
+cmake = { path = ".." }

--- a/test-crate/src/lib.rs
+++ b/test-crate/src/lib.rs
@@ -1,0 +1,13 @@
+#[cfg(test)]
+mod tests {
+    use libz_sys::zlibVersion;
+    use std::ffi::CStr;
+
+    #[test]
+    fn zlib_version() {
+        let ver = unsafe { zlibVersion() };
+        let ver_cstr = unsafe { CStr::from_ptr(ver) };
+        let version = ver_cstr.to_str().unwrap();
+        assert!(!version.is_empty());
+    }
+}


### PR DESCRIPTION
This PR changes `cmake-rs` to fill out `CMAKE_SYSTEM_NAME` and `CMAKE_SYSTEM_PROCESSOR` based `CARGO_CFG_TARGET_OS` and `CARGO_CFG_TARGET_ARCH` when cross compiling while `CMAKE_TOOLCHAIN_FILE` and `CMAKE_SYSTEM_NAME` isn't set by user.

It's tested on CI using [`cross`](https://github.com/cross-rs/cross).

Closes #75
Closes #80 
Closes #151