### PR TITLE
Various small cleanups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,24 +26,6 @@ jobs:
       run: rustup update stable && rustup default stable && rustup component add rustfmt
     - run: cargo fmt -- --check
 
-  publish_docs:
-    name: Publish Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Install Rust
-        run: rustup update stable && rustup default stable
-      - name: Build documentation
-        run: cargo doc --no-deps --all-features
-      - name: Publish documentation
-        run: |
-          cd target/doc
-          git init
-          git add .
-          git -c user.name='ci' -c user.email='ci' commit -m init
-          git push -f -q https://git:${{ secrets.github_token }}@github.com/${{ github.repository }} HEAD:gh-pages
-        if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
-
   cross_compile_test:
     name: Test Cross Compile - ${{ matrix.platform.target }}
     needs: [ test ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["build-dependencies"]
-repository = "https://github.com/alexcrichton/cmake-rs"
-homepage = "https://github.com/alexcrichton/cmake-rs"
+repository = "https://github.com/rust-lang/cmake-rs"
+homepage = "https://github.com/rust-lang/cmake-rs"
 documentation = "https://docs.rs/cmake"
 description = """
 A build dependency for running `cmake` to build a native library

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cmake"
 version = "0.1.48"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["build-dependencies"]
 repository = "https://github.com/rust-lang/cmake-rs"


### PR DESCRIPTION
- Update links in Cargo.toml to point at `rust-lang/cmake-rs`
- Use SPDX-compatible license format in Cargo.toml
- Remove support for publishing to github pages (since docs.rs exists)