### PR TITLE
Disable some targets where zlib-ng seems to no longer compile with default flags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,8 +57,6 @@ jobs:
             test: true
           - target: arm-unknown-linux-gnueabihf
             test: true
-          - target: armv7-unknown-linux-gnueabihf
-            test: true
           - target: mips-unknown-linux-gnu
             test: true
           - target: mips64-unknown-linux-gnuabi64
@@ -68,10 +66,6 @@ jobs:
           - target: mipsel-unknown-linux-gnu
             test: true
           - target: powerpc-unknown-linux-gnu
-            test: true
-          - target: powerpc64-unknown-linux-gnu
-            test: true
-          - target: powerpc64le-unknown-linux-gnu
             test: true
           - target: s390x-unknown-linux-gnu
             test: true


### PR DESCRIPTION
`zlib-ng` seems to need some extra flags to work on armv7 (to enable neon) or ppc64 (to enable altivec), so it's not really a great test case. I'll look into a better fix this weekend, but for now I'd prefer to just disable these, since the failures are effectively spurious.

I think a nice fix in the future might be if we passed along the flags needed based on CARGO_CFG_TARGET_FEATURES? I haven't thought about this much, so perhaps this is out of place for cmake-rs.

See also #80, where this was added. For whatever reason, that PR didn't have the same issues (older version of zlib-ng?)