### PR TITLE
Prep release 0.1.49

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmake"
-version = "0.1.48"
+version = "0.1.49"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This (like https://github.com/rust-lang/cc-rs/pull/737) will go out tomorrow or Sunday (hopefully tomorrow).

CC @Mark-Simulacrum, who will need to cut the actual release some automation is complete, but I'd rather not wait on that.