### PR TITLE
Revert #110 to fix iOS cross-compilation after #158. Fixes #173

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,3 +83,22 @@ jobs:
       run: cross build -vv --target ${{ matrix.platform.target }}
       working-directory: test-crate
       if: ${{ !matrix.platform.test }}
+
+  ios_cross_compile_test:
+    name: Test Cross Compile - ${{ matrix.platform.target }}
+    needs: [ test ]
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - target: aarch64-apple-ios
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.platform.target }}
+    - name: build
+      run: cargo build -vv --target ${{ matrix.platform.target }}
+      working-directory: test-crate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,3 +102,6 @@ jobs:
     - name: build
       run: cargo build -vv --target ${{ matrix.platform.target }}
       working-directory: test-crate
+      env:
+        # If this isn't specified the default is iOS 7, for which zlib-ng will not compile due to the lack of thread-local storage.
+        IPHONEOS_DEPLOYMENT_TARGET: 16

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         platform:
           - target: aarch64-apple-ios
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -660,12 +660,6 @@ impl Config {
                     panic!("unsupported msvc target: {}", target);
                 }
             }
-        } else if target.contains("apple-ios") || target.contains("apple-tvos") {
-            // These two flags prevent CMake from adding an OSX sysroot, which messes up compilation.
-            if !self.defined("CMAKE_OSX_SYSROOT") && !self.defined("CMAKE_OSX_DEPLOYMENT_TARGET") {
-                cmd.arg("-DCMAKE_OSX_SYSROOT=/");
-                cmd.arg("-DCMAKE_OSX_DEPLOYMENT_TARGET=");
-            }
         } else if target.contains("darwin") {
             if !self.defined("CMAKE_OSX_ARCHITECTURES") {
                 if target.contains("x86_64") {


### PR DESCRIPTION
In #158, better support for using CMake's cross-compilation facilities was added. This made the workaround added in #110 for iOS not only  unnecessary, but actively harmful, in that it runs afoul of SDK validation checks in the CMake iOS codepath.
    
This PR removes the workaround (reverting #110) and also adds a CI job to test an iOS cross-compile.