### PR TITLE
Fix for windows i686 cross-compilation target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,7 +484,7 @@ impl Config {
                         ("tvos", arch) => ("tvOS", arch),
                         ("watchos", arch) => ("watchOS", arch),
                         ("windows", "x86_64") => ("Windows", "AMD64"),
-                        ("windows", "i686") => ("Windows", "X86"),
+                        ("windows", "x86") => ("Windows", "X86"),
                         ("windows", "aarch64") => ("Windows", "ARM64"),
                         // Others
                         (os, arch) => (os, arch),


### PR DESCRIPTION
Was trying to cross-compile [`nng 1.0.1`](https://crates.io/crates/nng/1.0.1) crate with `cargo build --target i686-pc-windows-gnu`. It failed because `cmake` crate did not properly set `CMAKE_SYSTEM_NAME` define due to a failed match on target arch. Target supplied by `CARGO_CFG_TARGET_ARCH` is not `i686` but `x86`. Additional reference used: https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch.