### PR TITLE
Add JOM generator support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,6 +633,7 @@ impl Config {
                     false
                 } else {
                     generator.as_ref().unwrap() == "NMake Makefiles"
+                        || generator.as_ref().unwrap() == "NMake Makefiles JOM"
                 }
             };
             if !is_ninja && !using_nmake_generator {


### PR DESCRIPTION
This PR adds JOM generator support (fork of NMake with parallel execution). See details in the issue https://github.com/rust-lang/cmake-rs/issues/182