### PR TITLE
Introduce CMAKE_RS_SKIP_COMPILER_FLAG which remove use of CMAKE_C_COMPILER flag from cmake command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,7 +762,10 @@ impl Config {
                 // Also specify this on Windows only if we use MSVC with Ninja,
                 // as it's not needed for MSVC with Visual Studio generators and
                 // for MinGW it doesn't really vary.
-                if !self.defined("CMAKE_TOOLCHAIN_FILE")
+                let skip_compiler_flag =
+                    env::var("CMAKE_RS_SKIP_COMPILER_FLAG").ok() == Some("1".to_string());
+                if !skip_compiler_flag
+                    && !self.defined("CMAKE_TOOLCHAIN_FILE")
                     && !self.defined(&tool_var)
                     && (env::consts::FAMILY != "windows" || (msvc && is_ninja))
                 {


### PR DESCRIPTION
* This changes is required in order to build paho-mqtt for armv7-a using Yocto Poky compiler.