### PR TITLE
Set `CMAKE_SYSTEM_NAME=Generic` for bare-metal systems

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,6 +486,7 @@ impl Config {
                         ("windows", "x86_64") => ("Windows", "AMD64"),
                         ("windows", "x86") => ("Windows", "X86"),
                         ("windows", "aarch64") => ("Windows", "ARM64"),
+                        ("none", arch) => ("Generic", arch),
                         // Others
                         (os, arch) => (os, arch),
                     };


### PR DESCRIPTION
For targets without an operating system, the system name `Generic` is [recommended in the CMake documentation](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html#toolchain-files):
> [CMAKE_SYSTEM_NAME](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_NAME.html#variable:CMAKE_SYSTEM_NAME)
>
> This variable is mandatory; it sets the name of the target system, i.e. to the same value as CMAKE_SYSTEM_NAME would have if CMake were run on the target system. Typical examples are “Linux” and “Windows.” It is used for constructing the file names of the platform files like Linux.cmake or Windows-gcc.cmake. **If your target is an embedded system without an OS, set CMAKE_SYSTEM_NAME to “Generic.”**

This helps with some project configurations I have found.