### PR TITLE
Use `eprint` instead to print the command running next

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1062,7 +1062,7 @@ impl Default for Version {
 }
 
 fn run(cmd: &mut Command, program: &str) {
-    println!("running: {:?}", cmd);
+    eprintln!("running: {:?}", cmd);
     let status = match cmd.status() {
         Ok(status) => status,
         Err(ref e) if e.kind() == ErrorKind::NotFound => {


### PR DESCRIPTION
...to print an additional output to make it easier to reproduce the error.

This PR fixes #128.