### PR TITLE
Don't set CMAKE_SYSTEM_NAME when using the Visual Studio generator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,3 +105,22 @@ jobs:
       env:
         # If this isn't specified the default is iOS 7, for which zlib-ng will not compile due to the lack of thread-local storage.
         IPHONEOS_DEPLOYMENT_TARGET: 16
+
+  win_cross_compile_test:
+    name: Test Cross Compile - ${{ matrix.platform.target }}
+    needs: [ test ]
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - target: aarch64-pc-windows-msvc
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.platform.target }}
+    - name: build
+      run: cargo build -vv --target ${{ matrix.platform.target }}
+      working-directory: test-crate


### PR DESCRIPTION
Setting `CMAKE_SYSTEM_NAME` and `CMAKE_SYSTEM_PROCESSOR` is often enough for CMake to handle cross-compilation even without a toolchain file, but it gets in the way of generators that handle cross-compilation on their own (in Visual Studio's case, using the -T "toolset" option).

Narrow fix for the issue I brought up in https://github.com/rust-lang/cmake-rs/pull/158#issuecomment-1544695163. Possible fix for #171 as well, if it does turn out to be the same thing.