### PR TITLE
Make sure that cmake generate build files in current dir

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,6 +571,9 @@ impl Config {
         }
 
         cmd.arg(&self.path).current_dir(&build);
+
+        cmd.arg("-B").arg(".");
+
         let mut is_ninja = false;
         if let Some(ref generator) = generator {
             is_ninja = generator.to_string_lossy().contains("Ninja");


### PR DESCRIPTION
This should fix the `Error: could not load cache` BUG.

If there are already generated build files in the project directory, then if you execute the command `cmake path/project` in `$OUT_DIR/build`, cmake will not generate new build files in the `$OUT_DIR/build` directory.

So `-B .` is needed. https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-B

Example:

```sh
cd project
cmake .         # output `Build files have been written to: /path/to/project`
cd project/build
cmake ..        # [unexpected]: output `Build files have been written to: /path/to/project`
cmake .. -B .   # [expected]: `Build files have been written to: /path/to/project/build`
```
