### PR TITLE
Change `--build` to use an absolute path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -846,7 +846,7 @@ impl Config {
             }
         }
 
-        cmd.arg("--build").arg(".");
+        cmd.arg("--build").arg(&build);
 
         if !self.no_build_target {
             let target = self


### PR DESCRIPTION
We do set the current directory, but it seems that some flavors of CMake on Windows still fail with the following:

      MSBUILD : error MSB1009: Project file does not exist.  

Change to using an absolute path which should improve this.