### PR TITLE
Updates to fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Install Rust
-      run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      run: |
+        rustup update ${{ matrix.rust }} --no-self-update
+        rustup default ${{ matrix.rust }}
     - run: cargo test
     - name: Integration test
       run: cargo test --manifest-path test-crate/Cargo.toml
@@ -23,7 +25,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup component add rustfmt
+      run: |
+        rustup update stable --no-self-update
+        rustup default stable
+        rustup component add rustfmt
     - run: cargo fmt -- --check
 
   cross_compile_test:
@@ -60,11 +65,13 @@ jobs:
             test: false
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: ${{ matrix.platform.target }}
-    - uses: taiki-e/install-action@v1
+    - name: Install Rust
+      run: |
+        rustup update stable --no-self-update
+        rustup default stable
+        rustup target add ${{ matrix.platform.target }}
+    - run: cargo fmt -- --check
+    - uses: taiki-e/install-action@v2
       with:
         tool: cross
     - name: cross test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,8 +57,9 @@ jobs:
             test: false
           - target: x86_64-pc-windows-gnu
             test: false
-          - target: x86_64-unknown-freebsd
-            test: false
+          # FIXME: build fails, see <https://github.com/rust-lang/cmake-rs/issues/211>
+          # - target: x86_64-unknown-freebsd
+          #   test: false
           - target: x86_64-unknown-netbsd
             test: false
           - target: x86_64-unknown-illumos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,14 +39,6 @@ jobs:
             test: true
           - target: arm-unknown-linux-gnueabihf
             test: true
-          - target: mips-unknown-linux-gnu
-            test: true
-          - target: mips64-unknown-linux-gnuabi64
-            test: true
-          - target: mips64el-unknown-linux-gnuabi64
-            test: true
-          - target: mipsel-unknown-linux-gnu
-            test: true
           - target: powerpc-unknown-linux-gnu
             test: true
           - target: s390x-unknown-linux-gnu

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,14 +47,14 @@ jobs:
             test: true
           - target: aarch64-unknown-linux-musl
             test: true
-          - target: x86_64-pc-windows-gnu
-            test: true
           # Build only
+          - target: x86_64-pc-solaris
+            test: false
+          - target: x86_64-pc-windows-gnu
+            test: false
           - target: x86_64-unknown-freebsd
             test: false
           - target: x86_64-unknown-netbsd
-            test: false
-          - target: x86_64-sun-solaris
             test: false
           - target: x86_64-unknown-illumos
             test: false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -837,8 +837,7 @@ impl Config {
                         || cfg!(target_os = "openbsd")
                         || cfg!(target_os = "netbsd")
                         || cfg!(target_os = "freebsd")
-                        || cfg!(target_os = "bitrig")
-                        || cfg!(target_os = "dragonflybsd")) =>
+                        || cfg!(target_os = "dragonfly")) =>
                 {
                     use_jobserver = true;
                     cmd.env("MAKEFLAGS", makeflags);

--- a/test-crate/Cargo.toml
+++ b/test-crate/Cargo.toml
@@ -2,11 +2,10 @@
 name = "test-crate"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
-libz-sys = { version = "1.1.8", default-features = false, features = ["zlib-ng"] }
+libz-sys = { version = "1.1.19", default-features = false, features = ["zlib-ng"] }
 
 [patch.crates-io]
 cmake = { path = ".." }


### PR DESCRIPTION
- Disable MIPS
- Update outdated versions with check-cfg errors
- Update some instances of `check-cfg` failures in this crate
- Update Solaris target name
- Disable broken Windows and FreeBSD cross-compile tests (Windows has failures launching Wine, FreeBSD fails with https://github.com/rust-lang/cmake-rs/issues/211)
- Bump CI toolchain versions