### PR TITLE
Expose cc-rs `no_default_flags` for hassle-free cross-compilation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub struct Config {
     uses_cxx11: bool,
     always_configure: bool,
     no_build_target: bool,
+    no_default_flags: bool,
     verbose_cmake: bool,
     verbose_make: bool,
     pic: Option<bool>,
@@ -184,6 +185,7 @@ impl Config {
             path: env::current_dir().unwrap().join(path),
             generator: None,
             generator_toolset: None,
+            no_default_flags: false,
             cflags: OsString::new(),
             cxxflags: OsString::new(),
             asmflags: OsString::new(),
@@ -294,6 +296,13 @@ impl Config {
     /// Note that this isn't related to the target triple passed to the compiler!
     pub fn no_build_target(&mut self, no_build_target: bool) -> &mut Config {
         self.no_build_target = no_build_target;
+        self
+    }
+
+    /// Disables the generation of default compiler flags. The default compiler
+    /// flags may cause conflicts in some cross compiling scenarios.
+    pub fn no_default_flags(&mut self, no_default_flags: bool) -> &mut Config {
+        self.no_default_flags = no_default_flags;
         self
     }
 
@@ -515,7 +524,7 @@ impl Config {
             .debug(false)
             .warnings(false)
             .host(&host)
-            .no_default_flags(ndk);
+            .no_default_flags(ndk || self.no_default_flags);
         if !ndk {
             c_cfg.target(&target);
         }
@@ -527,7 +536,7 @@ impl Config {
             .debug(false)
             .warnings(false)
             .host(&host)
-            .no_default_flags(ndk);
+            .no_default_flags(ndk || self.no_default_flags);
         if !ndk {
             cxx_cfg.target(&target);
         }


### PR DESCRIPTION
In our own instantiation of `cmake-rs` `Config`, we would like to suppress the `cc-rs` logic that generates GCC flags based on Rust target triple analysis. Two reasons for that:
- The current logic in `cc-rs` [is not really working well for (at least some?) RISCV targets](https://github.com/rust-lang/cc-rs/issues/1262#issuecomment-2454918231)
- We anyway have all the necessary flags, and we would like to pass those as-is - no more - no less flags, so there is no real need for the cc-rs crate to help us in that