### PR TITLE
Add `define_bool` convention method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@
 //! use cmake::Config;
 //!
 //! let dst = Config::new("libfoo")
-//!                  .define("FOO", "BAR")
+//!                  .define("FOO", "BAR") // -DFOO=BAR
+//!                  .define_bool("BAZ", true) // -DBAZ=ON
 //!                  .cflag("-foo")
 //!                  .build();
 //! println!("cargo:rustc-link-search=native={}", dst.display());
@@ -270,6 +271,11 @@ impl Config {
         self.defines
             .push((k.as_ref().to_owned(), v.as_ref().to_owned()));
         self
+    }
+
+    /// Adds a new `-D` flag with a `ON`/`OFF` value to pass to cmake during the generation step.
+    pub fn define_bool<K: AsRef<OsStr>>(&mut self, k: K, v: bool) -> &mut Config {
+        self.define(k, if v { "ON" } else { "OFF" })
     }
 
     /// Registers a dependency for this compilation on the native library built


### PR DESCRIPTION
Implements #236 

Most CMake configurations use the `ON|OFF` convention to indicate a boolean value.  It would be more ergonomic to add a new setter like `fn define_bool(&mut self, key: &str, value: bool)`.  Some `build.rs` scripts could also compute these values during execution, so having this function would simplify

```rust
cfg.define("SOMETHING", if flag { "ON" } else { "OFF" });
```

into

```rust
cfg.define_bool("SOMETHING", flag);
```