### PR TITLE
Be more precise in the description of `register_dep`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,8 +275,11 @@ impl Config {
     /// Registers a dependency for this compilation on the native library built
     /// by Cargo previously.
     ///
-    /// This registration will modify the `CMAKE_PREFIX_PATH` environment
-    /// variable for the build system generation step.
+    /// This registration will update the `CMAKE_PREFIX_PATH` environment
+    /// variable for the [`build`][Self::build] system generation step.  The
+    /// path will be updated to include the content of the environment
+    /// variable `DEP_XXX_ROOT`, where `XXX` is replaced with the uppercased
+    /// value of `dep` (if that variable exists).
     pub fn register_dep(&mut self, dep: &str) -> &mut Config {
         self.deps.push(dep.to_string());
         self


### PR DESCRIPTION
It was not clear to me what the method `register_dep` was doing in a project I'm contributing—I had to look at the code of `cmake-rs`.  This aims to provide a more precise documentation of this function.