### PR TITLE
Document the path returned by Config::build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,6 +438,13 @@ impl Config {
     ///
     /// This will run both the build system generator command as well as the
     /// command to build the library.
+    ///
+    /// Returns the destination directory that the library was installed into,
+    /// which is the `CMAKE_INSTALL_PREFIX` passed to CMake and defaults to
+    /// Cargo's `$OUT_DIR`. Installed files follow the usual CMake layout under
+    /// this path, such as `lib` (or `lib64`) and `include`, so a build script
+    /// commonly joins those onto the returned path when emitting link search
+    /// paths.
     pub fn build(&mut self) -> PathBuf {
         let target = match self.target.clone() {
             Some(t) => t,


### PR DESCRIPTION
This documents what `Config::build` returns, which is the install prefix (`CMAKE_INSTALL_PREFIX`, defaulting to `$OUT_DIR`) rather than a specific library directory. Addresses #56.